### PR TITLE
WIP: FastQuantileLayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,20 @@ A few notes:
   | `relu`                       | Available       | Available |                               |
 
 
+## Running tests
+In order to install the full dependencies needed to test the whole package, 
+install with the tag `fql`.
+```
+python3 setup.py bdist_wheel 
+pip install dist/scikinC*.whl[fql]
+```
+
+Then run the tests with
+```
+pytest test
+```
+
+
 ## Related projects
   * [LWTNN](https://github.com/lwtnn/lwtnn)
   * [SimpleNN](https://gitlab.cern.ch/mschille/simplenn)

--- a/scikinC/FastQuantileLayerConverter.py
+++ b/scikinC/FastQuantileLayerConverter.py
@@ -38,7 +38,6 @@ class FastQuantileLayerConverter (BaseConverter):
 
       const FLOAT_T dx = (id < x_0f) ? 0. : (id > x_0f + 1) ? 1. : (id - x_0f);
 
-      fprintf (stderr, "%%f : %%f - %%f\\n", id, y_0, y_1);
       return y_0 + dx * (y_1 - y_0); 
     }
 

--- a/scikinC/FastQuantileLayerConverter.py
+++ b/scikinC/FastQuantileLayerConverter.py
@@ -1,0 +1,89 @@
+import numpy as np 
+from scikinC import BaseConverter 
+from scipy import stats
+from ._tools import array2c 
+
+
+
+class FastQuantileLayerConverter (BaseConverter):
+  def convert (self, model, name = None): 
+    lines = self.header() 
+
+    n_vars = len (model.fwdTransforms_)
+    xmin = [t.x_min for t in model.fwdTransforms_]
+    xmax = [t.x_max for t in model.fwdTransforms_]
+    yvalues = [t.tf_y_values.numpy() for t in model.fwdTransforms_]
+
+    ymin = [t.x_min for t in model.bwdTransforms_]
+    ymax = [t.x_max for t in model.bwdTransforms_]
+    xvalues = [t.tf_y_values.numpy() for t in model.bwdTransforms_]
+
+
+    lines . append ( """
+    #include <math.h>
+    #include <stdlib.h>
+    #include <stdio.h>
+
+    extern "C"
+    FLOAT_T ql_interpolate_for_%(name)s ( FLOAT_T x, FLOAT_T xmin, FLOAT_T xmax, const FLOAT_T *ys, int N )
+    {
+      if (xmax <= xmin) return 0./0.; 
+      const FLOAT_T range = xmax - xmin;
+      const FLOAT_T id = (x / range - xmin / range) * (N - 1);
+      const FLOAT_T x_0f = floor(id);
+      const int x_0 = int((x_0f < 0) ? 0 : (x_0f > (N-2)) ? (N-2) : x_0f);
+      const int x_1 = x_0 + 1; 
+      const FLOAT_T y_0 = ys[x_0];
+      const FLOAT_T y_1 = ys[x_1];
+
+      const FLOAT_T dx = (id < x_0f) ? 0. : (id > x_0f + 1) ? 1. : (id - x_0f);
+
+      fprintf (stderr, "%%f : %%f - %%f\\n", id, y_0, y_1);
+      return y_0 + dx * (y_1 - y_0); 
+    }
+
+
+    extern "C"
+    FLOAT_T *%(name)s (FLOAT_T *ret, const FLOAT_T *x)
+    {
+      int c; 
+      const FLOAT_T xmin[%(n_vars)d] = %(xmin)s; 
+      const FLOAT_T xmax[%(n_vars)d] = %(xmax)s; 
+      const FLOAT_T y[%(n_vars)d][%(n_y)d] = %(yvalues)s; 
+
+      for (c = 0; c < %(n_vars)d; ++c)
+        ret[c] = ql_interpolate_for_%(name)s (x[c], xmin[c], xmax[c], y[c], %(n_y)d ); 
+
+      return ret; 
+    }
+
+
+    extern "C"
+    FLOAT_T *%(name)s_inverse (FLOAT_T *ret, const FLOAT_T *y)
+    {
+      int c; 
+      const FLOAT_T ymin[%(n_vars)d] = %(ymin)s; 
+      const FLOAT_T ymax[%(n_vars)d] = %(ymax)s; 
+      const FLOAT_T x[%(n_vars)d][%(n_x)d] = %(xvalues)s; 
+
+      for (c = 0; c < %(n_vars)d; ++c)
+        ret[c] = ql_interpolate_for_%(name)s (y[c], ymin[c], ymax[c], x[c], %(n_x)d ); 
+
+      return ret; 
+    }
+    """ % dict(
+      name=name,
+      n_vars=n_vars,
+      n_y=len(yvalues[0]),
+      xmin=array2c(xmin),
+      xmax=array2c(xmax),
+      yvalues=array2c(yvalues),
+
+      n_x=len(xvalues[0]),
+      ymin=array2c(ymin),
+      ymax=array2c(ymax),
+      xvalues=array2c(xvalues),
+      )); 
+
+    return "\n".join (lines) 
+

--- a/scikinC/QuantileTransformerConverter.py
+++ b/scikinC/QuantileTransformerConverter.py
@@ -44,8 +44,39 @@ class QuantileTransformerConverter (BaseConverter):
     nQuantiles = model.quantiles_.shape[0] 
     nFeatures   = model.quantiles_.shape[1] 
     y = np.linspace (1e-7, 1.-1e-7, nQuantiles) 
-    if distr == 'normal':
-      y = stats.norm.ppf(y) 
+
+    nSamples = 1024
+    yAxis = np.linspace (-4, 4, nSamples)
+    xAxis = stats.norm.cdf (yAxis)
+
+    uniform_to_normal_string = """
+      FLOAT_T u[] = %(xAxis)s;
+      FLOAT_T norm[] = %(yAxis)s;
+
+      for (c = 0; c < %(nFeatures)d; ++c)
+        ret[c] = qtc_interpolate_for_%(name)s (ret[c], u, norm, %(n)d); 
+    """ % dict (
+          name = name, 
+          xAxis = array2c (xAxis), 
+          yAxis = array2c (yAxis), 
+          nFeatures = nFeatures,
+          n = nSamples,
+        )
+
+    normal_to_uniform_string = """
+      FLOAT_T u[] = %(xAxis)s;
+      FLOAT_T norm[] = %(yAxis)s;
+
+      for (c = 0; c < %(nFeatures)d; ++c)
+        x[c] = qtc_interpolate_for_%(name)s (x[c], norm, u, %(n)d); 
+    """ % dict (
+          name = name, 
+          xAxis = array2c (xAxis), 
+          yAxis = array2c (yAxis), 
+          nFeatures = nFeatures,
+          n = nSamples,
+        )
+
 
     lines.append ("""
     extern "C"
@@ -57,6 +88,8 @@ class QuantileTransformerConverter (BaseConverter):
 
       for (c = 0; c < %(nFeatures)d; ++c)
         ret[c] = qtc_interpolate_for_%(name)s (x[c], q[c], y, %(nQuantiles)d ); 
+      
+      %(to_normal_string)s
 
       return ret; 
     }
@@ -67,18 +100,26 @@ class QuantileTransformerConverter (BaseConverter):
       qString = array2c ( q.T ), #", ".join ([
         #"{%s}"%(", ".join ([str(x) for x in ql])) for ql in q.T]) ,
       yString = array2c ( y ), #", ".join ([str(x) for x in y]) 
+      to_normal_string = uniform_to_normal_string if distr=='normal' else '',
       )); 
 
     lines.append ("""
     extern "C"
-    FLOAT_T *%(name)s_inverse (FLOAT_T *ret, const FLOAT_T *x)
+    FLOAT_T *%(name)s_inverse (FLOAT_T *ret, const FLOAT_T *input)
     {
       int c; 
+      FLOAT_T x[%(nFeatures)d]; 
       FLOAT_T q[%(nFeatures)d][%(nQuantiles)d] = %(qString)s; 
       FLOAT_T y[%(nQuantiles)d] = %(yString)s; 
 
       for (c = 0; c < %(nFeatures)d; ++c)
+        x[c] = input[c]; 
+
+      %(to_uniform_string)s
+
+      for (c = 0; c < %(nFeatures)d; ++c)
         ret[c] = qtc_interpolate_for_%(name)s ( x[c], y, q[c], %(nQuantiles)d ); 
+
 
       return ret; 
     }
@@ -89,6 +130,7 @@ class QuantileTransformerConverter (BaseConverter):
       qString = array2c (q.T), #", ".join ([
         #"{%s}"%(", ".join ([str(x) for x in ql])) for ql in q.T]) ,
       yString = array2c (y), #", ".join ([str(x) for x in y]) 
+      to_uniform_string = normal_to_uniform_string if distr=='normal' else '',
       )); 
 
     return "\n".join (lines) 

--- a/scikinC/QuantileTransformerConverter.py
+++ b/scikinC/QuantileTransformerConverter.py
@@ -1,4 +1,5 @@
 import numpy as np 
+import sys
 from scikinC import BaseConverter 
 from scipy import stats
 from ._tools import array2c 
@@ -45,9 +46,15 @@ class QuantileTransformerConverter (BaseConverter):
     nFeatures   = model.quantiles_.shape[1] 
     y = np.linspace (1e-7, 1.-1e-7, nQuantiles) 
 
-    nSamples = 1024
-    yAxis = np.linspace (-4, 4, nSamples)
-    xAxis = stats.norm.cdf (yAxis)
+    nSamples = 512
+    xAxis = np.linspace (1e-7, 1.-1e-7, nSamples)
+    yAxis = stats.norm.ppf (xAxis)
+    yAxis [0] = stats.norm.ppf (1e-7 + np.spacing(1))
+    yAxis [-1] = stats.norm.ppf (1.-1e-7 + np.spacing(1))
+
+    #print (np.c_[y], file=sys.stderr)
+#    print (stats.norm.ppf(model.references_), file=sys.stderr)
+#    print (np.c_[xAxis, yAxis], file=sys.stderr)
 
     uniform_to_normal_string = """
       FLOAT_T u[] = %(xAxis)s;

--- a/scikinC/__init__.py
+++ b/scikinC/__init__.py
@@ -15,6 +15,7 @@ __CONVERTERS = {
       'QuantileTransformer': 'QuantileTransformerConverter', 
       'DecorrTransformer': 'DecorrTransformerConverter', 
       'Pipeline': 'PipelineConverter', 
+      'FastQuantileLayer': 'FastQuantileLayerConverter',
 
       ## Keras 
       'Sequential': 'KerasSequentialConverter', 

--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
 
     extras_require={  # Optional
         'keras': ['tensorflow', 'keras'],
+        'fql': ['tensorflow', 'keras', 'fastquantilelayer'],
     },
 
     entry_points={  # Optional

--- a/test/test_FastQuantileLayer.py
+++ b/test/test_FastQuantileLayer.py
@@ -19,7 +19,7 @@ def scaler_uniform():
 
 @pytest.fixture
 def scaler_bool():
-  scaler_ = FastQuantileLayer()
+  scaler_ = FastQuantileLayer(output_distribution='normal')
   X = np.random.choice ([0., 1.],(1000, 10), [0.8, 0.2])
   scaler_.fit (X) 
   return scaler_
@@ -27,7 +27,6 @@ def scaler_bool():
 @pytest.fixture
 def scaler_normal():
   scaler_ = FastQuantileLayer(output_distribution='normal')
-  X = np.ones((1000, 10))
   X = np.random.uniform (20,30,(1000, 10))
   scaler_.fit (X) 
   return scaler_
@@ -43,9 +42,7 @@ def test_forward (scaler, request):
   deployed = deploy_pickle("fastQL", scaler)
   xtest = np.random.uniform (20,30, 10)
   py = scaler.transform (xtest[None]).numpy()
-  print (py)
   c  = deployed.transform (10, xtest)
-  print (xtest, "->", c, " instead of: ", py)
   assert np.abs(py-c).max() < 1e-5
  
 

--- a/test/test_FastQuantileLayer.py
+++ b/test/test_FastQuantileLayer.py
@@ -1,0 +1,63 @@
+import numpy as np 
+from FastQuantileLayer import FastQuantileLayer
+
+# PyTest testing infrastructure
+import pytest
+
+# Local testing infrastructure
+from wrap import deploy_pickle 
+
+################################################################################
+## Test preparation
+
+@pytest.fixture
+def scaler_uniform():
+  scaler_ = FastQuantileLayer()
+  X = np.random.uniform (20,30,(1000, 10))
+  scaler_.fit (X) 
+  return scaler_
+
+@pytest.fixture
+def scaler_bool():
+  scaler_ = FastQuantileLayer()
+  X = np.random.choice ([0., 1.],(1000, 10), [0.8, 0.2])
+  scaler_.fit (X) 
+  return scaler_
+
+@pytest.fixture
+def scaler_normal():
+  scaler_ = FastQuantileLayer(output_distribution='normal')
+  X = np.ones((1000, 10))
+  X = np.random.uniform (20,30,(1000, 10))
+  scaler_.fit (X) 
+  return scaler_
+
+
+scalers = ['scaler_uniform', 'scaler_bool', 'scaler_normal']
+
+################################################################################
+## Real tests
+@pytest.mark.parametrize ('scaler', scalers)
+def test_forward (scaler, request):
+  scaler = request.getfixturevalue(scaler)
+  deployed = deploy_pickle("fastQL", scaler)
+  xtest = np.random.uniform (20,30, 10)
+  py = scaler.transform (xtest[None]).numpy()
+  print (py)
+  c  = deployed.transform (10, xtest)
+  print (xtest, "->", c, " instead of: ", py)
+  assert np.abs(py-c).max() < 1e-5
+ 
+
+@pytest.mark.parametrize ('scaler', scalers)
+def test_inverse (scaler, request):
+  scaler = request.getfixturevalue(scaler)
+  deployed = deploy_pickle("fastQL", scaler)
+  xtest = np.random.uniform (0,1, 10)
+  py = scaler.transform (xtest[None], inverse=True).numpy()
+  c  = deployed.transform_inverse (10, xtest)
+  assert np.abs(py-c).max() < 1e-5
+ 
+
+
+

--- a/test/test_GBDTC.py
+++ b/test/test_GBDTC.py
@@ -14,11 +14,11 @@ def classifier():
   classifier_ = GradientBoostingClassifier()
   X = np.concatenate (( 
       np.random.normal (0,2,(1000, 10)), 
-      np.random.normal (1,3,(1000, 10)), 
-      np.random.normal (2,4,(1000, 10)), 
+      np.random.normal (1,3,( 100, 10)), 
+      np.random.normal (2,4,(  10, 10)), 
       )) 
   y = np.array ( 
-      [0] * 1000 + [1] * 1000 + [2] * 1000 )
+      [0] * 1000 + [1] * 100 + [2] * 10 )
   classifier_.fit (X, y) 
   return classifier_
 
@@ -33,11 +33,11 @@ def deep_classifier():
   classifier_ = GradientBoostingClassifier(max_depth=8)
   X = np.concatenate (( 
       np.random.normal (0,2,(1000, 10)), 
-      np.random.normal (1,3,(1000, 10)), 
-      np.random.normal (2,4,(1000, 10)), 
+      np.random.normal (1,3,( 100, 10)), 
+      np.random.normal (2,4,(  10, 10)), 
       )) 
   y = np.array ( 
-      [0] * 1000 + [1] * 1000 + [2] * 1000 )
+      [0] * 1000 + [1] * 100 + [2] * 10 )
   classifier_.fit (X, y) 
   return classifier_
 

--- a/test/test_QuantileTransformer.py
+++ b/test/test_QuantileTransformer.py
@@ -18,7 +18,7 @@ def scaler_uniform():
 
 @pytest.fixture
 def scaler_normal():
-  scaler_ = QuantileTransformer(output_distribution='normal', n_quantiles=2)
+  scaler_ = QuantileTransformer(output_distribution='normal', n_quantiles=100)
   X = np.random.uniform (20,30,(1000, 10))
   scaler_.fit (X) 
   return scaler_
@@ -30,12 +30,29 @@ def scaler_bool_uniform():
   scaler_.fit (X) 
   return scaler_
 
+@pytest.fixture
+def scaler_bool_normal():
+  scaler_ = QuantileTransformer(output_distribution='normal')
+  X = np.random.choice ([22.,27.], (1000, 10), (0.8, 0.2))
+  scaler_.fit (X) 
+  return scaler_
+
+@pytest.fixture
+def scaler_delta_normal():
+  scaler_ = QuantileTransformer(output_distribution='normal')
+  X = np.full((10000,10), np.pi)
+  scaler_.fit (X) 
+  return scaler_
+
+
 
 
 scalers = [
     'scaler_uniform', 
     'scaler_normal',
     'scaler_bool_uniform',
+    'scaler_bool_normal',
+    'scaler_delta_normal',
     ]
 
 

--- a/test/test_QuantileTransformer.py
+++ b/test/test_QuantileTransformer.py
@@ -10,32 +10,56 @@ from wrap import deploy_pickle
 ################################################################################
 ## Test preparation
 @pytest.fixture
-def scaler():
+def scaler_uniform():
   scaler_ = QuantileTransformer()
   X = np.random.uniform (20,30,(1000, 10))
   scaler_.fit (X) 
   return scaler_
 
+@pytest.fixture
+def scaler_normal():
+  scaler_ = QuantileTransformer(output_distribution='normal', n_quantiles=2)
+  X = np.random.uniform (20,30,(1000, 10))
+  scaler_.fit (X) 
+  return scaler_
 
 @pytest.fixture
-def deployed(scaler):
-  return deploy_pickle("standardscaler", scaler)
+def scaler_bool_uniform():
+  scaler_ = QuantileTransformer(output_distribution='uniform')
+  X = np.random.choice ([22.,27.], (1000, 10), (0.8, 0.2))
+  scaler_.fit (X) 
+  return scaler_
+
+
+
+scalers = [
+    'scaler_uniform', 
+    'scaler_normal',
+    'scaler_bool_uniform',
+    ]
 
 
 ################################################################################
 ## Real tests
-def test_forward (scaler, deployed):
-  xtest = np.random.uniform (20,30, 10)
+@pytest.mark.parametrize ('scaler', scalers)
+def test_forward (scaler, request):
+  scaler = request.getfixturevalue(scaler)
+  deployed = deploy_pickle("quantiletransformer", scaler)
+  xtest = np.random.uniform (21,29, 10)
   py = scaler.transform (xtest[None])
   c  = deployed.transform (10, xtest)
-  assert np.abs(py-c).max() < 1e-5
+  print (xtest, "->", c, " instead of: ", py)
+  assert np.abs(py-c).max() < 1e-4
  
 
-def test_inverse (scaler, deployed):
+@pytest.mark.parametrize ('scaler', scalers)
+def test_inverse (scaler, request):
+  scaler = request.getfixturevalue(scaler)
+  deployed = deploy_pickle("quantiletransformer", scaler)
   xtest = np.random.uniform (0,1, 10)
   py = scaler.inverse_transform (xtest[None])
   c  = deployed.transform_inverse (10, xtest)
-  assert np.abs(py-c).max() < 1e-5
+  assert np.abs(py-c).max() < 1e-4
  
 
 


### PR DESCRIPTION
FastQuantileLayer is an implentation of the scikit-learn QuantileTransformer that can be directly implemented in keras. 
To be faster in the interpolation, it uses a different algorithm from QuantileTransformer which behaves differently from QuantileTransformer in corner cases (as for example when the training sample includes discrete variables).

The new converter reproduces exactly the same behaviour as FastQuantileLayer making it possible to export networks trained with that tool. 

Missing to accept the merge-request:
- [x] update  of the setup.py to include the FastQuantileLayer package necessary for tests

See also: https://github.com/landerlini/FastQuantileLayer